### PR TITLE
Ajout du Tag Manager Matomo 

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -242,3 +242,4 @@ WAGTAILEMBEDS_GRIST_HEIGHT = 400
 # ---------------------------------------
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_URL = os.getenv("MATOMO_URL")
+MATOMO_TAG_MANAGER_CONTAINER = os.getenv("MATOMO_TAG_MANAGER_CONTAINER")

--- a/config/settings_context_processors.py
+++ b/config/settings_context_processors.py
@@ -9,4 +9,5 @@ def expose_settings(request):
     return {
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MATOMO_URL": settings.MATOMO_URL,
+        "MATOMO_TAG_MANAGER_CONTAINER": settings.MATOMO_TAG_MANAGER_CONTAINER,
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,21 +56,32 @@
             {% endblock content %}
         </main>
         {% include "blocks/footer.html" %}
-        {% if MATOMO_SITE_ID and MATOMO_URL %}
-            <!-- Matomo -->
-            <script>
-                var _paq = window._paq = window._paq || [];
-                _paq.push(['trackPageView']);
-                _paq.push(['enableLinkTracking']);
-                (function() {
-                var u="{{ MATOMO_URL }}";
-                _paq.push(['setTrackerUrl', u+'piwik.php']);
-                _paq.push(['setSiteId', '{{ MATOMO_SITE_ID }}']);
-                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-                })();
-            </script>
-            <!-- End Matomo Code -->
+        {% if MATOMO_URL %}
+            {% if MATOMO_SITE_ID %}
+                <!-- Matomo -->
+                <script>
+                    var _paq = window._paq = window._paq || [];
+                    _paq.push(['trackPageView']);
+                    _paq.push(['enableLinkTracking']);
+                    (function() {
+                    var u="{{ MATOMO_URL }}";
+                    _paq.push(['setTrackerUrl', u+'piwik.php']);
+                    _paq.push(['setSiteId', '{{ MATOMO_SITE_ID }}']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+                    })();
+                </script>
+                <!-- End Matomo Code -->
+            {% elif MATOMO_TAG_MANAGER_CONTAINER %}
+                <!-- Matomo Tag Manager -->
+                <script>
+                    var _mtm = window._mtm = window._mtm || [];
+                    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.async=true; g.src='{{ MATOMO_URL }}/js/container_{{ MATOMO_TAG_MANAGER_CONTAINER }}.js'; s.parentNode.insertBefore(g,s);
+                </script>
+                <!-- End Matomo Tag Manager -->
+            {% endif %}
         {% endif %}
         {% dsfr_js %}
         {% block extra_js %}


### PR DESCRIPTION
L'ajout du Tag Manager Matomo avec le container permet de suivre des objectifs dans Matomo.

Pour le mettre en œuvre, il suffit alors de **définir les variables d'environnement** `MATOMO_URL` et `MATOMO_TAG_MANAGER_CONTAINER`  et de **ne pas définir** la variable `MATOMO_SITE_ID`.