### PR TITLE
Fix to Makefile for Github runner images compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       - name: ✨ Black, isort, flake8
         run: |
           make quality
+        env:
+          USE_VENV: 1
       - name: 🚧 Check pending migrations
         run: |
           django-admin makemigrations --check --dry-run --noinput

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifeq ($(USE_VENV),1)
 	EXEC_CMD :=
 else
-	EXEC_CMD := docker-compose exec -ti web
+	EXEC_CMD := docker compose exec -ti web
 endif
 
 .PHONY: web-prompt

--- a/cms/embeds_finders.py
+++ b/cms/embeds_finders.py
@@ -1,6 +1,6 @@
 import re
-
 from urllib.parse import urlparse
+
 from django.conf import settings
 from wagtail.embeds.finders.base import EmbedFinder
 
@@ -26,6 +26,7 @@ class GristFinder(EmbedFinder):
             "html": html,
         }
 
+
 class MetabaseFinder(EmbedFinder):
     def __init__(self, **options):
         pass
@@ -42,13 +43,13 @@ class MetabaseFinder(EmbedFinder):
         return f"//{self.metabase_domain(url)}{settings.WAGTAILEMBEDS_METABASE_IFRAME_RESIZER_URL}"
 
     def find_embed(self, url, max_width=None):
-        html = f'''
+        html = f"""
             <iframe src="{url}" height="{settings.WAGTAILEMBEDS_METABASE_HEIGHT}" width="100%"></iframe>
             <script src="{self.resizer_url(url)}"></script>
             <script>
                 iFrameResize({{}}, "iframe");
             </script>
-        '''
+        """
         return {
             "title": "Metabase Embed",
             "author_name": "Plateforme de l'inclision",

--- a/cms/migrations/0010_alter_contentpage_body.py
+++ b/cms/migrations/0010_alter_contentpage_body.py
@@ -199,7 +199,10 @@ class Migration(migrations.Migration):
                                 (
                                     "url",
                                     wagtail.blocks.URLBlock(
-                                        help_text="URL au format 'embed' (Ex. : https://www.youtube.com/embed/gLzXOViPX-0)",
+                                        help_text=(
+                                            "URL au format 'embed' (Ex. : "
+                                            "https://www.youtube.com/embed/gLzXOViPX-0)"
+                                        ),
                                         label="Lien de la vidéo",
                                     ),
                                 ),
@@ -233,7 +236,9 @@ class Migration(migrations.Migration):
                                     "bg_color",
                                     wagtail.blocks.RegexBlock(
                                         error_messages={
-                                            "invalid": "La couleur n'est pas correcte, le format doit être #fff ou #f5f5fe"
+                                            "invalid": (
+                                                "La couleur n'est pas correcte, le format doit être #fff ou #f5f5fe"
+                                            )
                                         },
                                         label="Couleur d'arrière plan au format hexa (Ex: #f5f5fe)",
                                         regex="^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
@@ -263,7 +268,10 @@ class Migration(migrations.Migration):
                                                         (
                                                             "alt",
                                                             wagtail.blocks.CharBlock(
-                                                                label="Texte alternatif (description textuelle de l'image)",
+                                                                label=(
+                                                                    "Texte alternatif (description textuelle de "
+                                                                    "l'image)"
+                                                                ),
                                                                 required=False,
                                                             ),
                                                         ),
@@ -290,7 +298,10 @@ class Migration(migrations.Migration):
                                                         (
                                                             "url",
                                                             wagtail.blocks.URLBlock(
-                                                                help_text="URL au format 'embed' (Ex. : https://www.youtube.com/embed/gLzXOViPX-0)",
+                                                                help_text=(
+                                                                    "URL au format 'embed' (Ex. : "
+                                                                    "https://www.youtube.com/embed/gLzXOViPX-0)"
+                                                                ),
                                                                 label="Lien de la vidéo",
                                                             ),
                                                         ),
@@ -317,7 +328,11 @@ class Migration(migrations.Migration):
                                                         (
                                                             "document",
                                                             wagtail.documents.blocks.DocumentChooserBlock(
-                                                                help_text="Sélectionnez un document pour rendre la carte cliquable vers celui ci (si le champ `Lien` n'est pas renseigné).",
+                                                                help_text=(
+                                                                    "Sélectionnez un document pour rendre la carte "
+                                                                    "cliquable vers celui ci (si le champ `Lien` "
+                                                                    "n'est pas renseigné)."
+                                                                ),
                                                                 label="ou Document",
                                                                 required=False,
                                                             ),
@@ -391,7 +406,10 @@ class Migration(migrations.Migration):
                                                         (
                                                             "cta_label",
                                                             wagtail.blocks.CharBlock(
-                                                                help_text="Le lien apparait comme un bouton sous le bloc de texte",
+                                                                help_text=(
+                                                                    "Le lien apparait comme un bouton sous "
+                                                                    "le bloc de texte"
+                                                                ),
                                                                 label="Titre de l'appel à l'action",
                                                                 required=False,
                                                             ),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   db:
     image: postgres:14.5-alpine

--- a/services/management/commands/syncbetadata.py
+++ b/services/management/commands/syncbetadata.py
@@ -141,11 +141,11 @@ class Command(BaseCommand):
         try:
             service = ServicePage.objects.get(beta_id=service_id)
             service.delete()
-            self.stdout.write(f"Service deleted!")
+            self.stdout.write(f"Service id {service_id} deleted!")
 
             # TODO: check if add redirection to avoid 404 is needed
         except ServicePage.DoesNotExist:
-            self.stdout.write(f"Service already deleted.")
+            self.stdout.write(f"Service id {service_id} already deleted.")
             pass  # service already deleted
 
     def create_or_update_member(self, member_id, services, attributes):

--- a/services/management/commands/syncbetadata.py
+++ b/services/management/commands/syncbetadata.py
@@ -141,11 +141,11 @@ class Command(BaseCommand):
         try:
             service = ServicePage.objects.get(beta_id=service_id)
             service.delete()
-            self.stdout.write(f"Service id {service_id} deleted!")
+            self.stdout.write("Service deleted!")
 
             # TODO: check if add redirection to avoid 404 is needed
         except ServicePage.DoesNotExist:
-            self.stdout.write(f"Service id {service_id} already deleted.")
+            self.stdout.write("Service already deleted.")
             pass  # service already deleted
 
     def create_or_update_member(self, member_id, services, attributes):

--- a/services/migrations/0010_alter_servicepage_body.py
+++ b/services/migrations/0010_alter_servicepage_body.py
@@ -133,7 +133,10 @@ class Migration(migrations.Migration):
                                 (
                                     "url",
                                     wagtail.blocks.URLBlock(
-                                        help_text="URL au format 'embed' (Ex. : https://www.youtube.com/embed/gLzXOViPX-0)",
+                                        help_text=(
+                                            "URL au format 'embed' (Ex. : "
+                                            "https://www.youtube.com/embed/gLzXOViPX-0)"
+                                        ),
                                         label="Lien de la vidéo",
                                     ),
                                 ),
@@ -167,7 +170,9 @@ class Migration(migrations.Migration):
                                     "bg_color",
                                     wagtail.blocks.RegexBlock(
                                         error_messages={
-                                            "invalid": "La couleur n'est pas correcte, le format doit être #fff ou #f5f5fe"
+                                            "invalid": (
+                                                "La couleur n'est pas correcte, le format doit être #fff ou #f5f5fe"
+                                            )
                                         },
                                         label="Couleur d'arrière plan au format hexa (Ex: #f5f5fe)",
                                         regex="^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
@@ -197,7 +202,10 @@ class Migration(migrations.Migration):
                                                         (
                                                             "alt",
                                                             wagtail.blocks.CharBlock(
-                                                                label="Texte alternatif (description textuelle de l'image)",
+                                                                label=(
+                                                                    "Texte alternatif (description "
+                                                                    "textuelle de l'image)"
+                                                                ),
                                                                 required=False,
                                                             ),
                                                         ),
@@ -224,7 +232,10 @@ class Migration(migrations.Migration):
                                                         (
                                                             "url",
                                                             wagtail.blocks.URLBlock(
-                                                                help_text="URL au format 'embed' (Ex. : https://www.youtube.com/embed/gLzXOViPX-0)",
+                                                                help_text=(
+                                                                    "URL au format 'embed' (Ex. : "
+                                                                    "https://www.youtube.com/embed/gLzXOViPX-0)"
+                                                                ),
                                                                 label="Lien de la vidéo",
                                                             ),
                                                         ),
@@ -247,11 +258,18 @@ class Migration(migrations.Migration):
                                                                 label="Image", required=False
                                                             ),
                                                         ),
-                                                        ("url", wagtail.blocks.URLBlock(label="Lien", required=False)),
+                                                        (
+                                                            "url",
+                                                            wagtail.blocks.URLBlock(label="Lien", required=False),
+                                                        ),
                                                         (
                                                             "document",
                                                             wagtail.documents.blocks.DocumentChooserBlock(
-                                                                help_text="Sélectionnez un document pour rendre la carte cliquable vers celui ci (si le champ `Lien` n'est pas renseigné).",
+                                                                help_text=(
+                                                                    "Sélectionnez un document pour rendre la carte "
+                                                                    "cliquable vers celui ci (si le champ `Lien` "
+                                                                    "n'est pas renseigné)."
+                                                                ),
                                                                 label="ou Document",
                                                                 required=False,
                                                             ),
@@ -325,7 +343,10 @@ class Migration(migrations.Migration):
                                                         (
                                                             "cta_label",
                                                             wagtail.blocks.CharBlock(
-                                                                help_text="Le lien apparait comme un bouton sous le bloc de texte",
+                                                                help_text=(
+                                                                    "Le lien apparait comme un bouton sous "
+                                                                    "le bloc de texte"
+                                                                ),
                                                                 label="Titre de l'appel à l'action",
                                                                 required=False,
                                                             ),

--- a/well_known/urls.py
+++ b/well_known/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import path
 
 from .views import serve_text_file
 

--- a/well_known/urls.py
+++ b/well_known/urls.py
@@ -1,6 +1,5 @@
 from django.urls import include, path
 
-
 from .views import serve_text_file
 
 

--- a/well_known/views.py
+++ b/well_known/views.py
@@ -1,12 +1,13 @@
 import os
+
 from django.http import HttpResponse
 
 
 def serve_text_file(request, file_name):
-    file_path = os.path.join('static', '.well-known', file_name)
+    file_path = os.path.join("static", ".well-known", file_name)
     try:
-        with open(file_path, 'rb') as file:
+        with open(file_path, "rb") as file:
             content = file.read()
-        return HttpResponse(content, content_type='text/plain; charset=utf-8')
+        return HttpResponse(content, content_type="text/plain; charset=utf-8")
     except FileNotFoundError:
         return HttpResponse(b"File not found.", status=404)


### PR DESCRIPTION
Runner images on Github have deprecated old docker compose syntax. Cf. https://github.com/actions/runner-images/issues/9864