### PR TITLE
Suivi des recos SIG pour les liens du footer

### DIFF
--- a/templates/blocks/footer.html
+++ b/templates/blocks/footer.html
@@ -117,6 +117,16 @@
                     <li class="fr-footer__content-item">
                         <a class="fr-footer__content-link"
                            target="_blank"
+                           href="https://info.gouv.fr">info.gouv.fr</a>
+                    </li>
+                    <li class="fr-footer__content-item">
+                        <a class="fr-footer__content-link"
+                           target="_blank"
+                           href="https://legifrance.gouv.fr">legifrance.gouv.fr</a>
+                    </li>
+                    <li class="fr-footer__content-item">
+                        <a class="fr-footer__content-link"
+                           target="_blank"
                            href="https://data.gouv.fr">data.gouv.fr</a>
                     </li>
                     <li class="fr-footer__content-item">

--- a/templates/blocks/footer.html
+++ b/templates/blocks/footer.html
@@ -122,6 +122,11 @@
                     <li class="fr-footer__content-item">
                         <a class="fr-footer__content-link"
                            target="_blank"
+                           href="https://service-public.fr">service-public.fr</a>
+                    </li>
+                    <li class="fr-footer__content-item">
+                        <a class="fr-footer__content-link"
+                           target="_blank"
                            href="https://legifrance.gouv.fr">legifrance.gouv.fr</a>
                     </li>
                     <li class="fr-footer__content-item">


### PR DESCRIPTION
Une circulaire (lien mattermost: https://mattermost.incubateur.net/betagouv/pl/djq6todku7gc3kgy5b6bh6ww1w) mentionne les sites à mettre en pied de page.