### PR TITLE
Fix breadcrumb UI in banner layout

### DIFF
--- a/cms/templates/cms/content_page.html
+++ b/cms/templates/cms/content_page.html
@@ -9,7 +9,6 @@
     {% endblock description %}
 {% endif %}
 {% block content %}
-    {% include "cms/breadcrumb.html" %}
     {# Display Django message info from previous form #}
     {% if messages %}
         <div class="fr-container fr-mt-6w">
@@ -39,6 +38,7 @@
         {% if block.block_type == 'hero' %}
             {% include "cms/blocks/hero.html" %}
         {% elif block.block_type == 'title' %}
+            {% include "cms/breadcrumb.html" %}
             <div class="fr-container fr-mt-6w">
                 <div class="fr-grid-row fr-grid-row--gutters">
                     <div class="fr-col-12{% if not block.value.large %} fr-col-offset-md-2 fr-col-md-8{% endif %}">

--- a/services/templates/services/servicepage_list.html
+++ b/services/templates/services/servicepage_list.html
@@ -2,11 +2,17 @@
 {% load static dsfr_tags wagtailcore_tags wagtailimages_tags %}
 {% block content %}
     <div style="background: url({% static 'images/fond-nos-services.png' %}) #f5f5fe no-repeat center">
-        <div class="fr-container fr-pt-2w fr-pb-6w">
+        <div class="fr-container fr-mt-1w">
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col-12">
                     {% dsfr_breadcrumb %}
-                    <h1 class="fr-display--sm">Nos services numériques</h1>
+                </div>
+            </div>
+        </div>
+        <div class="fr-container fr-pb-14w">
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    <h1>Nos services numériques</h1>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Pourquoi

Pour harmoniser la mise en page des zones de titres

### Comment
Suppression de l'espace vide en trop au-dessus des bannières et inclusion du fil d'arianne dans la zone de bannière


**Avant**
![capture 2025-03-17 à 11 37 48](https://github.com/user-attachments/assets/7048b63a-1922-45d7-9860-5876f5a6f33b)


**Apres**
![capture 2025-03-17 à 11 37 39](https://github.com/user-attachments/assets/0ecb1606-582d-414d-9721-76b7ca265c10)