### PR TITLE
Make heroblock background image optional

### DIFF
--- a/cms/migrations/0010_alter_contentpage_body.py
+++ b/cms/migrations/0010_alter_contentpage_body.py
@@ -25,7 +25,12 @@ class Migration(migrations.Migration):
                         "hero",
                         wagtail.blocks.StructBlock(
                             [
-                                ("bg_image", wagtail.images.blocks.ImageChooserBlock(label="Image d'arrière plan")),
+                                (
+                                    "bg_image",
+                                    wagtail.images.blocks.ImageChooserBlock(
+                                        label="Image d'arrière plan", required=False
+                                    ),
+                                ),
                                 (
                                     "bg_color",
                                     wagtail.blocks.CharBlock(

--- a/cms/models.py
+++ b/cms/models.py
@@ -15,7 +15,7 @@ class WithSpacingBlock(blocks.StructBlock):
 
 
 class HeroBlock(blocks.StructBlock):
-    bg_image = ImageChooserBlock(label="Image d'arrière plan")
+    bg_image = ImageChooserBlock(label="Image d'arrière plan", required=False)
     bg_color = blocks.CharBlock(
         label="Couleur d'arrière plan au format hexa (Ex: #f5f5fe)",
         min_length=4,

--- a/cms/templates/cms/blocks/hero.html
+++ b/cms/templates/cms/blocks/hero.html
@@ -1,7 +1,12 @@
 {% load wagtailimages_tags %}
 {% image block.value.bg_image original as bg_img %}
 <div class="hero"
-     style="background: url({{ bg_img.url }}) {{ block.value.bg_color }} no-repeat center">
+    {% if bg_img.url %}
+        style="background: url({{ bg_img.url }}) {{ block.value.bg_color }} no-repeat center"
+    {% else %}
+        style="background-color: {{ block.value.bg_color }}"
+    {% endif %}
+    >
     <div class="fr-container fr-py-14w">
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col fr-col-12 fr-col-md-6">


### PR DESCRIPTION
### Pourquoi
Afin de pouvoir ajouter des hero block sur certaine pages (politique de confidentialité, mentions legales etc) pour avoir une belle zone de titre avec un `<h1>`, même sans image de fond

### Comment
Ne pas rendre obligatoire l'image de background dans le hero block de wagtail
