### PR TITLE
Disable S3 file overwrite

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -174,6 +174,7 @@ AWS_S3_SECRET_ACCESS_KEY = os.getenv("S3_KEY_SECRET", "secret")
 AWS_S3_ENDPOINT_URL = f"{os.getenv('S3_PROTOCOL', 'https')}://{os.getenv('S3_HOST', 'set-var-env.com/')}"
 AWS_STORAGE_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "set-bucket-name")
 AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_BUCKET_REGION", "fr")
+AWS_S3_FILE_OVERWRITE = False
 # CleverCloud S3 implementation does not support recent data integrity features from AWS.
 # https://github.com/boto/boto3/issues/4392
 # https://github.com/boto/boto3/issues/4398#issuecomment-2619946229


### PR DESCRIPTION
```
2025-03-20 17:22:55.946234894 +0100 CET [postdeploy-2662] System check identified some issues:
2025-03-20 17:22:55.946242112 +0100 CET [postdeploy-2662] 	HINT: This should be set to False. The incorrect setting can cause documents and other user-uploaded files to be silently overwritten or deleted.
2025-03-20 17:22:55.946241446 +0100 CET [postdeploy-2662] ?: (wagtailadmin.W004) The AWS_S3_FILE_OVERWRITE setting is set to True
```