### PR TITLE
Mise à jour des liens vers nos réseaux sociaux

### DIFF
--- a/templates/blocks/footer.html
+++ b/templates/blocks/footer.html
@@ -17,12 +17,6 @@
                                title="Page Linkedin de La Plateforme de l'inclusion - nouvelle fenêtre">linkedin</a>
                         </li>
                         <li>
-                            <a class="fr-btn--facebook fr-btn"
-                               href="https://www.facebook.com/communaute.inclusion.gouv"
-                               target="_blank"
-                               title="Page Facebook de La Communauté de l'inclusion - nouvelle fenêtre">facebook</a>
-                        </li>
-                        <li>
                             <a class="fr-btn--youtube fr-btn"
                                href="https://www.youtube.com/@LaPlateformedelinclusion/videos"
                                target="_blank"

--- a/templates/blocks/footer.html
+++ b/templates/blocks/footer.html
@@ -18,21 +18,15 @@
                         </li>
                         <li>
                             <a class="fr-btn--facebook fr-btn"
-                               href="https://www.facebook.com/inclusion.gouv/"
+                               href="https://www.facebook.com/communaute.inclusion.gouv"
                                target="_blank"
-                               title="Page Facebook de La Plateforme de l'inclusion - nouvelle fenêtre">facebook</a>
+                               title="Page Facebook de La Communauté de l'inclusion - nouvelle fenêtre">facebook</a>
                         </li>
                         <li>
-                            <a class="fr-btn--instagram fr-btn"
-                               href="https://www.instagram.com/inclusion_gouv/"
+                            <a class="fr-btn--youtube fr-btn"
+                               href="https://www.youtube.com/@LaPlateformedelinclusion/videos"
                                target="_blank"
-                               title="Page Instagram de La Plateforme de l'inclusion - nouvelle fenêtre">instagram</a>
-                        </li>
-                        <li>
-                            <a class="fr-btn--twitter fr-btn"
-                               href="https://twitter.com/inclusion_gouv"
-                               target="_blank"
-                               title="Compte Twitter de La Plateforme de l'inclusion - nouvelle fenêtre">twitter</a>
+                               title="Page Youtube de La Plateforme de l'inclusion - nouvelle fenêtre">youtube</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcque le [compte a été supprimé](https://gip-inclusion.slack.com/archives/CQEMZRMRP/p1744362468685729)
Parcque le lien facebook n'était plus bon
Parcque le compte instagram n'existe plus
Parcque le lien youtube n'était pas renseigné alors que le compte semble actif
